### PR TITLE
add pyplot savefig()

### DIFF
--- a/persim/visuals.py
+++ b/persim/visuals.py
@@ -17,7 +17,10 @@ def plot_diagrams(
     lifetime=False,
     legend=True,
     show=False,
-    ax=None
+    ax=None,
+    save=False,
+    figures_directory=None,
+    filename=None
 ):
     """A helper function to plot persistence diagrams. 
 
@@ -174,6 +177,9 @@ def plot_diagrams(
 
     if show is True:
         plt.show()
+
+    if save is True:
+        plt.savefig(figures_directory + filename)
 
 
 def bottleneck_matching(I1, I2, matchidx, D, labels=["dgm1", "dgm2"], ax=None):


### PR DESCRIPTION
I am using Ripser.py alongside a Docker container running all the python stuff. This makes plotting tricky if at all possible. The workaround is simply to use pyplot.savefig() and save the plots as files. 

This pull request is a naive attempt to enable figure saving functionality to Ripser.py. Suggestions, edits and/ or corrections are welcome.