### PR TITLE
added link to preprint, fixed backward compatibility

### DIFF
--- a/persim/gromov_hausdorff.py
+++ b/persim/gromov_hausdorff.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 """
-    Implementation of the modified Gromov-Hausdorff (mGH) distance
-    between compact metric spaces induced by unweighted graphs based on
-    their shortest path length. The mGH distance was first defined in
-    "Some properties of Gromov–Hausdorff distances" by F. Mémoli
-    (Discrete & Computational Geometry, 2012).
+    Implementation of the modified Gromov–Hausdorff (mGH) distance
+    between compact metric spaces induced by unweighted graphs. This
+    code complements the results from "Efficient estimation of a
+    Gromov–Hausdorff distance between unweighted graphs" by V. Oles et
+    al. (https://arxiv.org/pdf/1909.09772). The mGH distance was first
+    defined in "Some properties of Gromov–Hausdorff distances" by F.
+    Mémoli (Discrete & Computational Geometry, 2012).
 
     Author: Vladyslav Oles
 
@@ -29,7 +31,7 @@
     >>> A_I = np.array([[0, 1], [0, 0]])
     >>> A_J = sps.csr_matrix(([1] * 5, ([0, 0, 1, 2, 3], [1, 4, 2, 3, 4])), shape=(5, 5))
     >>> lb, ub = gromov_hausdorff(A_I, A_J)
-    >>> print(lb, ub)
+    >>> lb, ub
     (0.5, 1.0)
 
     3) Estimating all pairwise mGH distances between multiple graphs
@@ -38,15 +40,15 @@
     >>> As = [A_G, A_H, A_I, A_J]
     >>> LB, UB = gromov_hausdorff(As)
     >>> LB
-    [[0.  0.5 0.5 0.5]
-     [0.5 0.  0.5 1. ]
-     [0.5 0.5 0.  0.5]
-     [0.5 1.  0.5 0. ]]
+    array([[0. , 0.5, 0.5, 0.5],
+           [0.5, 0. , 0.5, 1. ],
+           [0.5, 0.5, 0. , 0.5],
+           [0.5, 1. , 0.5, 0. ]])
     >>> UB
-    [[0.  0.5 0.5 0.5]
-     [0.5 0.  0.5 1. ]
-     [0.5 0.5 0.  1. ]
-     [0.5 1.  1.  0. ]]
+    array([[0. , 0.5, 0.5, 0.5],
+           [0.5, 0. , 0.5, 1. ],
+           [0.5, 0.5, 0. , 1. ],
+           [0.5, 1. , 1. , 0. ]])
 
     ===================================================================
 
@@ -58,7 +60,7 @@
 
     V(G) denotes vertex set of graph G.
 
-    mGH(X, Y) denotes the modified Gromov-Hausdorff distance between
+    mGH(X, Y) denotes the modified Gromov–Hausdorff distance between
     compact metric spaces X and Y.
 
     ===================================================================
@@ -793,4 +795,3 @@ def construct_mapping(D_X, D_Y, pi):
         distortion = max(bottlenecks_from_mapping_x[y], distortion)
         
     return mapped_xs_images, distortion
-

--- a/persim/gromov_hausdorff.py
+++ b/persim/gromov_hausdorff.py
@@ -511,10 +511,12 @@ def find_unique_maximal_distributions(distributions):
         np.all(pairwise_distribution_differences >= 0, axis=2),
         np.any(pairwise_distribution_differences > 0, axis=2))
     distributions_are_maximal = ~np.any(pairwise_distribution_less_thans, axis=1)
-    # `np.unique` replaced for compatibility with Python 3.4/NumPy 1.12.
-    # unique_maximal_distributions = np.unique(distributions[distributions_are_maximal], axis=0)
-    unique_maximal_distributions = np.vstack(
-        {tuple(distribution) for distribution in distributions[distributions_are_maximal]})
+    try:
+        unique_maximal_distributions = np.unique(distributions[distributions_are_maximal], axis=0)
+    except AttributeError:
+        # `np.unique` is not implemented in NumPy 1.12 (Python 3.4).
+        unique_maximal_distributions = np.vstack(
+            {tuple(distribution) for distribution in distributions[distributions_are_maximal]})
 
     return unique_maximal_distributions
 

--- a/test/test_distances.py
+++ b/test/test_distances.py
@@ -6,7 +6,7 @@ import pytest
 from persim import bottleneck, wasserstein
 from persim import sliced_wasserstein
 from persim import heat
-from persim import gromov_hausdorff, gromov_hausdorff
+from persim import gromov_hausdorff
 
 
 class TestBottleneck:


### PR DESCRIPTION
Specified the paper with theoretical results upon which the implementation is based. Unconditional use of the backward compatibility code is replaced with running it only when needed (NumPy <= 1.12). Minor fixes: doctests in `gromov-hausdorff.py`, redundant import in `test_distances.py`, 