### PR TITLE
Removed the memory layout specification in numpy.copy() that was causing a problem.

### DIFF
--- a/persim/persim.py
+++ b/persim/persim.py
@@ -70,7 +70,7 @@ class PersImage(TransformerMixin):
         if singular:
             diagrams = [diagrams]
 
-        dgs = [np.copy(diagram, np.float64) for diagram in diagrams]
+        dgs = [np.copy(diagram) for diagram in diagrams]
         landscapes = [PersImage.to_landscape(dg) for dg in dgs]
 
         if not self.specs:


### PR DESCRIPTION
Previously, a specification 'numpy.float64' was used in the function np.copy(). This option was deprecated in numpy version 1.18. Calling the function without an explicit memory layout specification preserves the layout of the object that is being copied. This change should be also compatible with older version of numpy.