### PR TITLE
Fixed a problem with a numpy 1.18 deprecation

### DIFF
--- a/persim/images.py
+++ b/persim/images.py
@@ -91,7 +91,7 @@ class PersImage(TransformerMixin):
         if singular:
             diagrams = [diagrams]
 
-        dgs = [np.copy(diagram, np.float64) for diagram in diagrams]
+        dgs = [np.copy(diagram) for diagram in diagrams]
         landscapes = [PersImage.to_landscape(dg) for dg in dgs]
 
         if not self.specs:


### PR DESCRIPTION
Removed the 'numpy.float64' memory layout specification in the arguments of a numpy.copy() function. The syntax for explicit specification of the memory layout in some numpy functions, including numpy.copy(), has been altered as of version 1.18, which resulted in an error message when computing persistence images. The change should be compatible with older versions of numpy, because the default option for memory layout specification was not changed in numpy version 1.18. 