### PR TITLE
Fixed outdated dependency - collections.Iteratable moved to collections.abc.Iterable in Python 3.3+

### DIFF
--- a/persim/images.py
+++ b/persim/images.py
@@ -1,10 +1,6 @@
 from __future__ import division
 from itertools import product
-import collections
-try:
-    collectionsAbc = collections.abc
-except AttributeError:
-    collectionsAbc = collections
+import collections.abc
 
 import copy
 import numpy as np
@@ -90,7 +86,7 @@ Parameters
             return np.zeros((self.nx, self.ny))
         # if first entry of first entry is not iterable, then diagrams is singular and we need to make it a list of diagrams
         try:
-            singular = not isinstance(diagrams[0][0], collectionsAbc.Iterable)
+            singular = not isinstance(diagrams[0][0], collections.abc.Iterable)
         except IndexError:
             singular = False
 
@@ -619,7 +615,7 @@ class PersistenceImager(TransformerMixin):
     def _ensure_iterable(self, pers_dgms):
         # if first entry of first entry is not iterable, then diagrams is singular and we need to make it a list of diagrams
         try:
-            singular = not isinstance(pers_dgms[0][0], collectionsAbc.Iterable)
+            singular = not isinstance(pers_dgms[0][0], collections.abc.Iterable)
         except IndexError:
             singular = False
 

--- a/persim/images.py
+++ b/persim/images.py
@@ -1,6 +1,10 @@
 from __future__ import division
 from itertools import product
 import collections
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
 
 import copy
 import numpy as np
@@ -86,7 +90,7 @@ Parameters
             return np.zeros((self.nx, self.ny))
         # if first entry of first entry is not iterable, then diagrams is singular and we need to make it a list of diagrams
         try:
-            singular = not isinstance(diagrams[0][0], collections.Iterable)
+            singular = not isinstance(diagrams[0][0], collectionsAbc.Iterable)
         except IndexError:
             singular = False
 
@@ -615,7 +619,7 @@ class PersistenceImager(TransformerMixin):
     def _ensure_iterable(self, pers_dgms):
         # if first entry of first entry is not iterable, then diagrams is singular and we need to make it a list of diagrams
         try:
-            singular = not isinstance(pers_dgms[0][0], collections.Iterable)
+            singular = not isinstance(pers_dgms[0][0], collectionsAbc.Iterable)
         except IndexError:
             singular = False
 


### PR DESCRIPTION
As per title. Persim breaks when using Python 3.3+ as the dependancy collections.Iterable has been moved.

We check if collections.abc exists, and if so, use that instead.