### PR TITLE
Fix Wasserstein Distance Computation Bug

### DIFF
--- a/persim/wasserstein.py
+++ b/persim/wasserstein.py
@@ -87,10 +87,7 @@ def wasserstein(dgm1, dgm2, matching=False):
     UR = np.inf*np.ones((M, M))
     np.fill_diagonal(UR, S[:, 1])
     D[0:M, N:N+M] = UR
-    UL = np.inf*np.ones((N, N))
-    np.fill_diagonal(UL, T[:, 1])
-    D[M:N+M, 0:N] = UL
-
+    
     # Step 2: Run the hungarian algorithm
     matchi, matchj = optimize.linear_sum_assignment(D)
     matchdist = np.sum(D[matchi, matchj])


### PR DESCRIPTION
This pull request addresses an issue related to the computation of Wasserstein distance in our codebase. Specifically, the UL matrix is removed due to a phenomenon where certain rows after the M-th row in the Hungarian algorithm, match with themselves which creates a distance greater than zero so it creates inaccuracies in the resultant distance calculation.

**Changes Made**
Removing the UL matrix results in eliminating erroneous values in the Wasserstein distance calculation.

**Impact**
This fix ensures more accurate computation of Wasserstein distance by eliminating erroneous additions to the distance metric, thereby improving the overall reliability of our codebase.