### PR TITLE
bottleneck and wasserstein matching plots use supplied axes

### DIFF
--- a/persim/visuals.py
+++ b/persim/visuals.py
@@ -223,7 +223,7 @@ def bottleneck_matching(dgm1, dgm2, matching, labels=["dgm1", "dgm2"], ax=None):
             if i == -1:
                 diagElem = np.array([dgm2Rot[j, 0], 0])
                 diagElem = diagElem.dot(R.T)
-                plt.plot([dgm2[j, 0], diagElem[0]], [dgm2[j, 1], diagElem[1]], c, linewidth=linewidth, linestyle=linestyle)
+                ax.plot([dgm2[j, 0], diagElem[0]], [dgm2[j, 1], diagElem[1]], c, linewidth=linewidth, linestyle=linestyle)
             elif j == -1:
                 diagElem = np.array([dgm1Rot[i, 0], 0])
                 diagElem = diagElem.dot(R.T)
@@ -277,7 +277,7 @@ def wasserstein_matching(dgm1, dgm2, matching, labels=["dgm1", "dgm2"], ax=None)
             if i == -1:
                 diagElem = np.array([dgm2Rot[j, 0], 0])
                 diagElem = diagElem.dot(R.T)
-                plt.plot([dgm2[j, 0], diagElem[0]], [dgm2[j, 1], diagElem[1]], "g")
+                ax.plot([dgm2[j, 0], diagElem[0]], [dgm2[j, 1], diagElem[1]], "g")
             elif j == -1:
                 diagElem = np.array([dgm1Rot[i, 0], 0])
                 diagElem = diagElem.dot(R.T)


### PR DESCRIPTION
A bug in bottleneck_matching and wasserstein_matching means that they ignore the supplied axes if `i==-1`. This pull request fixes that bug.

Example that triggers the bug
```
dgm1 = np.array([
    [0.6, 1.05],
    [0.53, 1],
])
dgm2 = np.array([
    [0.55, 1.1],
    [0.8,0.9],
    [0.5, 0.51]
])

d, matching = persim.bottleneck(
    dgm1,
    dgm2,
    matching=True
)
fig,ax = plt.subplots(2)
persim.bottleneck_matching(dgm1, dgm2, matching, ax=ax[0])
plt.show()

d, wmatching = persim.wasserstein(dgm1, dgm2, matching=True)

fig,ax = plt.subplots(2)
persim.wasserstein_matching(dgm1, dgm2, matching=wmatching, ax=ax[0])
plt.show()

```